### PR TITLE
Fix Versionsnummer von jQuery

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -20,7 +20,7 @@ var AktInfoTerminalStartseiteAufrufenWebadresse = MApreferences.InfoTerminalStar
 
 pageMod.PageMod({
     include: "*",
-    contentScriptFile: [ data.url("js/jquery/jquery-2.1.0.min.js"),
+    contentScriptFile: [ data.url("js/jquery/jquery-2.1.3.min.js"),
                          data.url("js/erzeuge-home-button.js")],
     contentStyleFile: data.url("css/externe.css"),
     // contentStyle is built dynamically here to include an absolute URL


### PR DESCRIPTION
- Momentan erscheint der folgende Fehler auf der Browser Konsole: ""Error opening input stream (invalid filename?): resource://jumphomema-at-jetpack/jumphomema/data/js/jquery/jquery-2.1.0.min.js" core.js:91"
- Der Patch hier gleicht die Versionsnummer an 2.1.3 an.
- Dies müsste man wohl auch noch ins xpi nachziehen.

Signed-off-by: Philipp Zumstein zuphilip@gmail.com
